### PR TITLE
Add apikey header

### DIFF
--- a/01_setup_private_keys.sql
+++ b/01_setup_private_keys.sql
@@ -15,14 +15,10 @@ REVOKE ALL ON TABLE private.keys FROM PUBLIC;
 -- [SUPABASE_SERVICE_KEY]
 -- Supabase Dashboard / settings / api / sevice_role (secret)
 
--- [SUPABASE_API_KEY]
--- Supabase Dashboard / settings / api / anon (public)
-
 ************************************************************************
 *** NOTE: the service_role key is sensitive, DO NOT SHARE IT PUBICLY ***
 ************************************************************************/
 
 INSERT INTO private.keys (key, value) values ('SUPABASE_API_URL', '[SUPABASE_API_URL]');
 INSERT INTO private.keys (key, value) values ('SUPABASE_SERVICE_KEY', '[SUPABASE_SERVICE_KEY]');
-INSERT INTO private.keys (key, value) values ('SUPABASE_API_KEY', '[SUPABASE_API_KEY]');
 

--- a/01_setup_private_keys.sql
+++ b/01_setup_private_keys.sql
@@ -14,10 +14,15 @@ REVOKE ALL ON TABLE private.keys FROM PUBLIC;
 
 -- [SUPABASE_SERVICE_KEY]
 -- Supabase Dashboard / settings / api / sevice_role (secret)
+
+-- [SUPABASE_API_KEY]
+-- Supabase Dashboard / settings / api / anon (public)
+
 ************************************************************************
 *** NOTE: the service_role key is sensitive, DO NOT SHARE IT PUBICLY ***
 ************************************************************************/
 
 INSERT INTO private.keys (key, value) values ('SUPABASE_API_URL', '[SUPABASE_API_URL]');
 INSERT INTO private.keys (key, value) values ('SUPABASE_SERVICE_KEY', '[SUPABASE_SERVICE_KEY]');
+INSERT INTO private.keys (key, value) values ('SUPABASE_API_KEY', '[SUPABASE_API_KEY]');
 

--- a/02_generate_auth_link_function.sql
+++ b/02_generate_auth_link_function.sql
@@ -8,7 +8,6 @@ declare
     retval text;
     SUPABASE_API_URL text;
     SUPABASE_SERVICE_KEY text;
-    SUPABASE_API_KEY text;
 begin
 
     SELECT value::text INTO SUPABASE_API_URL FROM private.keys WHERE key = 'SUPABASE_API_URL';
@@ -17,9 +16,6 @@ begin
     SELECT value::text INTO SUPABASE_SERVICE_KEY FROM private.keys WHERE key = 'SUPABASE_SERVICE_KEY';
     IF NOT found THEN RAISE 'missing entry in private.keys: SUPABASE_SERVICE_KEY'; END IF;
 
-    SELECT value::text INTO SUPABASE_API_KEY FROM private.keys WHERE key = 'SUPABASE_API_KEY';
-    IF NOT found THEN RAISE 'missing entry in private.keys: SUPABASE_API_KEY'; END IF;
-
     SELECT
         content INTO retval
     FROM
@@ -27,7 +23,7 @@ begin
         SUPABASE_API_URL || '/auth/v1/admin/generate_link',
         ARRAY[
             http_header ('Authorization', 'Bearer ' || SUPABASE_SERVICE_KEY),
-            http_header ('apikey', SUPABASE_API_KEY)
+            http_header ('apikey', SUPABASE_SERVICE_KEY)
         ],
         'application/json', 
         payload::text

--- a/02_generate_auth_link_function.sql
+++ b/02_generate_auth_link_function.sql
@@ -24,7 +24,7 @@ begin
         content INTO retval
     FROM
         http (('POST', 
-        SUPABASE_API_URL || '/auth/v1/admin/generate_link?apikey=' || SUPABASE_SERVICE_KEY,
+        SUPABASE_API_URL || '/auth/v1/admin/generate_link',
         ARRAY[
             http_header ('Authorization', 'Bearer ' || SUPABASE_SERVICE_KEY),
             http_header ('apikey', SUPABASE_API_KEY)

--- a/02_generate_auth_link_function.sql
+++ b/02_generate_auth_link_function.sql
@@ -8,6 +8,7 @@ declare
     retval text;
     SUPABASE_API_URL text;
     SUPABASE_SERVICE_KEY text;
+    SUPABASE_API_KEY text;
 begin
 
     SELECT value::text INTO SUPABASE_API_URL FROM private.keys WHERE key = 'SUPABASE_API_URL';
@@ -16,13 +17,18 @@ begin
     SELECT value::text INTO SUPABASE_SERVICE_KEY FROM private.keys WHERE key = 'SUPABASE_SERVICE_KEY';
     IF NOT found THEN RAISE 'missing entry in private.keys: SUPABASE_SERVICE_KEY'; END IF;
 
+    SELECT value::text INTO SUPABASE_API_KEY FROM private.keys WHERE key = 'SUPABASE_API_KEY';
+    IF NOT found THEN RAISE 'missing entry in private.keys: SUPABASE_API_KEY'; END IF;
+
     SELECT
         content INTO retval
     FROM
         http (('POST', 
         SUPABASE_API_URL || '/auth/v1/admin/generate_link?apikey=' || SUPABASE_SERVICE_KEY,
-        ARRAY[http_header ('Authorization', 
-        'Bearer ' || SUPABASE_SERVICE_KEY)], 
+        ARRAY[
+            http_header ('Authorization', 'Bearer ' || SUPABASE_SERVICE_KEY),
+            http_header ('apikey', SUPABASE_API_KEY)
+        ],
         'application/json', 
         payload::text
     ));


### PR DESCRIPTION
This PR fixes an issue  https://github.com/burggraf/supabase-roll-your-own-auth/issues/1 with `generate_link` api method authorization. It adds additional `apikey` header.
